### PR TITLE
Add color to presets

### DIFF
--- a/presets.json
+++ b/presets.json
@@ -25,7 +25,8 @@
     "Materials": {
       "init_type": 0,
       "E": [1.0],
-      "nu": [0.25]
+      "nu": [0.25],
+      "color": ["#000000"]
     },
     "Optimizer": {
       "filter_type": "Sensitivity",
@@ -75,7 +76,8 @@
     "Materials": {
       "init_type": 0,
       "E": [1.0],
-      "nu": [0.25]
+      "nu": [0.25],
+      "color": ["#000000"]
     },
     "Optimizer": {
       "filter_type": "Sensitivity",
@@ -117,7 +119,8 @@
     "Materials": {
       "init_type": 0,
       "E": [1.0],
-      "nu": [0.25]
+      "nu": [0.25],
+      "color": ["#000000"]
     },
     "Optimizer": {
       "filter_type": "Sensitivity",
@@ -159,7 +162,8 @@
     "Materials": {
       "init_type": 0,
       "E": [0.1],
-      "nu": [0.25]
+      "nu": [0.25],
+      "color": ["#000000"]
     },
     "Optimizer": {
       "filter_type": "Sensitivity",
@@ -244,7 +248,8 @@
     "Materials": {
       "E": [1.0],
       "nu": [0.25],
-      "init_type": 0
+      "init_type": 0,
+      "color": ["#000000"]
     },
     "Optimizer": {
       "filter_type": "Sensitivity",
@@ -289,7 +294,8 @@
     "Materials": {
       "init_type": 0,
       "E": [1.0],
-      "nu": [0.25]
+      "nu": [0.25],
+      "color": ["#000000"]
     },
     "Optimizer": {
       "filter_type": "Sensitivity",

--- a/tests/presets_test.json
+++ b/tests/presets_test.json
@@ -308,7 +308,6 @@
             "E": [1.0],
             "nu": [0.25],
             "percent": [100],
-            "color": ["#000000"],
             "init_type": 2
         },
         "Optimizer": {


### PR DESCRIPTION
Add black color to all presets which didn't have one.
Removed the color from one preset test to check that it also works even if a preset doesn't have a color assigned.