### PR TITLE
Fix displacement preview

### DIFF
--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -560,9 +560,9 @@ class MainWindow(QMainWindow, PlottingMixin, ParameterManagerMixin):
         if is_3d:
             ax.clear()
             self.plot_material(ax, is_3d, frame_data)
-            self.redraw_non_material_layers(ax, is_3d=True)
 
         else:
+            # we don't use plot_material here because we use set_array instead of imshow
             if not ax.images:
                 return
             im = ax.images[0]
@@ -585,8 +585,15 @@ class MainWindow(QMainWindow, PlottingMixin, ParameterManagerMixin):
 
                 im.set_array(final_image)
             else:
-                # Single-material fallback
                 im.set_array(frame_data.reshape((nelx, nely)).T)
+
+            # Remove old layers like previous forces, regions, and especially the undeformed displacement preview
+            # that were drawn prior to the animation starting.
+            for coll in list(ax.collections):
+                coll.remove()
+            for patch in list(ax.patches):
+                patch.remove()
+        self.redraw_non_material_layers(ax, is_3d)
 
         # Redraw the canvas to show the changes
         self.canvas.draw()

--- a/app/ui/plotting.py
+++ b/app/ui/plotting.py
@@ -779,6 +779,8 @@ class PlottingMixin:
             ).flatten()
             material_mask = (
                 self.xPhys[el_indices] > 0.5
+                if self.xPhys.ndim == 1
+                else np.any(self.xPhys[:, el_indices] > 0.5, axis=0)
             )  # Only show arrows in material regions
 
             # Get the coordinates and displacement vectors for the valid points
@@ -815,6 +817,8 @@ class PlottingMixin:
 
             material_mask = (
                 self.xPhys[el_indices] > 0.5
+                if self.xPhys.ndim == 1
+                else np.any(self.xPhys[:, el_indices] > 0.5, axis=0)
             )  # Only show arrows in material regions
 
             # Get the coordinates and displacement vectors for the valid points


### PR DESCRIPTION
- Fix crash when previewing the displacement of a multi-material mechanism
- Hide displacement preview for multi-iteration displacement of 2D mechanisms as it is for single displacement