### PR TITLE
Link material percentages

### DIFF
--- a/app/ui/plotting.py
+++ b/app/ui/plotting.py
@@ -202,7 +202,7 @@ class PlottingMixin:
                 all_z,
             )
 
-        if "Regions" in self.last_params:
+        if self.xPhys is not None and "Regions" in self.last_params:
             self._apply_regions(nelx, nely, nelz, is_3d)
 
     def _apply_regions(self, nelx, nely, nelz, is_3d):
@@ -256,9 +256,12 @@ class PlottingMixin:
                         indices = jj + ii * nely
 
             if indices is not None:
-                self.xPhys[:, indices.flatten()] = (
-                    1e-6 if pr["rstate"][i] == "Void" else 1.0
-                )
+                value = 1e-6 if pr["rstate"][i] == "Void" else 1.0
+                flat_idx = indices.flatten()
+                if self.xPhys.ndim == 1:
+                    self.xPhys[flat_idx] = value
+                else:
+                    self.xPhys[:, flat_idx] = value
 
     def _show_initial_message(self, ax, is_3d):
         """Displays initial placeholder message onto canvas before optimization results exist."""

--- a/app/ui/widgets.py
+++ b/app/ui/widgets.py
@@ -840,6 +840,7 @@ class MaterialsWidget(QWidget):
         line1.addWidget(QLabel("%:"))
         mat_percent = _make_spin(0, 100, percent, 70, "Volume Fraction percentage")
         mat_percent.setSingleStep(5)
+        mat_percent.valueChanged.connect(self._on_percent_changed)
         line1.addWidget(mat_percent)
         line1.addStretch()
         layout.addLayout(line1)
@@ -902,9 +903,29 @@ class MaterialsWidget(QWidget):
         mat["container"].deleteLater()
         mat["container"].setParent(None)
 
+        self.inputs[0]["percent"].blockSignals(True)
+        self.inputs[0]["percent"].setValue(100)
+        self.inputs[0]["percent"].blockSignals(False)
+
         if emit_signal:
             self.nbMaterialsChanged.emit()
         self.update_ui_state()
+
+    def _on_percent_changed(self, value):
+        """When there are exactly 2 materials, auto-adjust the other to keep sum = 100."""
+        if len(self.inputs) == 1:
+            self.inputs[0]["percent"].setValue(100)
+        elif len(self.inputs) == 2:
+            sender = self.sender()
+            if sender is self.inputs[0]["percent"]:
+                other = self.inputs[1]["percent"]
+            elif sender is self.inputs[1]["percent"]:
+                other = self.inputs[0]["percent"]
+            else:
+                return
+            other.blockSignals(True)
+            other.setValue(100 - value)
+            other.blockSignals(False)
 
     def update_ui_state(self):
         # Update Add/Remove buttons state

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -267,6 +267,11 @@ def test_material_widget_initialization(qt_app):
         widget.inputs[1]["percent"], QSpinBox
     )
 
+    # Test material equilibrium
+    widget.inputs[0]["percent"].setValue(70)
+    qt_app.processEvents()
+    assert widget.inputs[1]["percent"].value() == 30, "Percent do not sum to 100%."
+
     # Test remove button
     new_support["remove_btn"].click()
     qt_app.processEvents()


### PR DESCRIPTION
- Linked material percentages: modifying one updates the other (see _on_percent_changed() ). this also helps prevent the following crash.
- Fix crash when plotting regions when material percentages didn't sum to 100% (see _initialize_xphys() )
- Fix crash when plotting regions in single-material case (see _apply_regions() )