### PR TITLE
Fix crash when first force was inactive

### DIFF
--- a/app/core/fem.py
+++ b/app/core/fem.py
@@ -204,26 +204,15 @@ class FEM:
         ce_total = np.zeros(self.nel)
 
         if nb_out == 0:  # Rigid Mechanism (Minimize Compliance)
-            for i_in in self.fi_indices:
+            for i_in in range(len(self.fi_indices)):
                 Ue = ui[self.edofMat, i_in]
-                if self.is_3d:
-                    ce_total += np.sum(np.dot(Ue, self.KE) * Ue, axis=1)
-                else:
-                    ce_total += np.einsum("ij,jk,ik->i", Ue, self.KE, Ue)
+                ce_total += np.sum((Ue @ self.KE) * Ue, axis=1)
         else:  # Compliant Mechanism
-            if self.is_3d:
-                for el in range(self.nel):
-                    for i_in in self.fi_indices:
-                        Ue_in = ui[self.edofMat[el, :], [i_in]]
-                        for i_out in self.fo_indices:
-                            Ue_out = uo[self.edofMat[el, :], [i_out]]
-                            ce_total[el] += (Ue_in.T @ self.KE @ Ue_out).item()
-            else:
-                for i_in in self.fi_indices:
-                    Ue_in = ui[self.edofMat, i_in]
-                    for i_out in self.fo_indices:
-                        Ue_out = uo[self.edofMat, i_out]
-                        ce_total += np.einsum("ij,jk,ik->i", Ue_in, self.KE, Ue_out)
+            for i_in in range(len(self.fi_indices)):
+                Ue_in = ui[self.edofMat, i_in]
+                for i_out in range(len(self.fo_indices)):
+                    Ue_out = uo[self.edofMat, i_out]
+                    ce_total += np.sum((Ue_in @ self.KE) * Ue_out, axis=1)
 
         return ce_total
 
@@ -285,7 +274,8 @@ class FEM:
         kdir: str,
         knorm: str,
     ):
-        fx, fy = Forces.get(kx, []), Forces.get(ky, [])
+        fx = Forces.get(kx, [])
+        fy = Forces.get(ky, [])
         fz = Forces.get(kz, []) if self.is_3d else []
         fdir = Forces.get(kdir, [])
 

--- a/app/core/optimizers.py
+++ b/app/core/optimizers.py
@@ -227,7 +227,8 @@ def optimize_multimaterial(
     g = np.zeros(n_mat)
 
     # Optimization Params
-    eta, max_change = Optimizer.get("eta", 1.0), Optimizer.get("max_change", 0.1)
+    eta = Optimizer.get("eta", 1.0)
+    max_change = Optimizer.get("max_change", 0.1)
     n_it = Optimizer.get("n_it", 30)
 
     if verbose:
@@ -246,7 +247,7 @@ def optimize_multimaterial(
         ui, uo = fem.solve(xPhys)
 
         # Optional: Compute Objective Value for Console Output (can also be computed inside compute_sensitivities for efficiency)
-        obj_val = fem.compute_objective(xPhys[i], ui, uo)
+        obj_val = fem.compute_objective(xPhys, ui, uo)
 
         # Per-material sensitivity & OC update
         for i in range(n_mat):

--- a/tests/test_fem.py
+++ b/tests/test_fem.py
@@ -106,7 +106,7 @@ def test_boundary_conditions_parsing(base_config_2d):
         "fix": [2],
         "fiy": [1],
         "fiz": [],
-        "fidir": ["Y"],
+        "fidir": ["Y:\u2191"],
         "finorm": [1.0],
         # Output forces (required by parse logic even if empty)
         "fox": [],
@@ -135,16 +135,16 @@ def test_solver_mechanics(base_config_2d):
     Supports = {"sx": [0, 0], "sy": [0, 1], "sz": [], "sdim": ["XY", "XY"]}
     # Pull right edge (x=2, y=0) to the right (X)
     Forces = {
-        "fix": [2],
-        "fiy": [0],
+        "fix": [0, 2],
+        "fiy": [0, 0],
         "fiz": [],
-        "fidir": ["X"],
-        "finorm": [1.0],
-        "fox": [],
-        "foy": [],
+        "fidir": ["-", "X:\u2192"],
+        "finorm": [1.0, 1.0],
+        "fox": [0, 1],
+        "foy": [0, 1],
         "foz": [],
-        "fodir": [],
-        "fonorm": [],
+        "fodir": ["-", "Y:\u2191"],
+        "fonorm": [1.0, 1.0],
     }
 
     fem.setup_boundary_conditions(Forces, Supports)
@@ -157,7 +157,7 @@ def test_solver_mechanics(base_config_2d):
 
     # Check dimensions
     assert ui.shape == (fem.ndof, 1)
-    assert uo.shape == (fem.ndof, 0)
+    assert uo.shape == (fem.ndof, 1)
 
     # The node at force application (x=2, y=0) is Node index 4 -> DOF 8 (X)
     assert ui[8, 0] > 0.0, (
@@ -176,11 +176,11 @@ def test_sensitivities_calculation(base_config_2d):
     # Minimal BCs to ensure stability
     Supports = {"sx": [0], "sy": [0], "sz": [], "sdim": ["XY"]}
     Forces = {
-        "fix": [2],
-        "fiy": [0],
+        "fix": [2, 0],
+        "fiy": [0, 0],
         "fiz": [],
-        "fidir": ["X"],
-        "finorm": [1.0],
+        "fidir": ["X:\u2192", "-"],
+        "finorm": [1.0, 1.0],
         "fox": [],
         "foy": [],
         "foz": [],
@@ -215,12 +215,12 @@ def test_regions_void(base_config_2d):
 
     # Define a void region at x=0, y=0
     Regions = {
-        "rx": [0],
-        "ry": [0],
+        "rx": [0, 0],
+        "ry": [0, 0],
         "rz": [],
-        "rradius": [1],  # Small radius covering the element center
-        "rshape": ["□"],  # Square
-        "rstate": ["Void"],
+        "rradius": [1, 1],  # Small radius covering the element center
+        "rshape": ["-", "□"],  # Square
+        "rstate": ["Void", "Void"],
     }
 
     x = np.ones(fem.nel)  # Start fully solid


### PR DESCRIPTION
In compute_ce function, iterate on range(len()) instead of the indices value.
The function has been vectorized btw.
Harden tests (see test_fem.py)