### PR TITLE
Fix tests overriding results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,15 +3,16 @@ __pycache__/
 *.py[cod]
 
 # Saved results
-results/*/*.png
-results/*/*.stl
-results/*/*.vti
-results/*/*.3mf
-results/*/*_creation/
-results/*/*_displacement/
+/results/*/*.png
+/results/*/*.stl
+/results/*/*.vti
+/results/*/*.3mf
+/results/*/*_creation/
+/results/*/*_displacement/
 
 # Test outputs
-/Tests/test_output*
+/tests/test_output*
+/tests/*/*.npz
 .coverage
 
 # Build (when an executable is created)

--- a/app/cli.py
+++ b/app/cli.py
@@ -32,7 +32,6 @@ def _run_single_preset(
     """Run optimization and export for a single preset. Returns (preset_name, error)."""
     if verbose:
         print(f"Running optimization for preset: {preset_name}")
-
     xPhys: FloatArray | None = None
     u: FloatArray | None = None
     # Detect if running from pytest and use tests/ instead of results/
@@ -137,7 +136,6 @@ def _run_single_preset(
                     )
         except Exception as e:
             import traceback
-
             traceback.print_exc()
             return preset_name, f"Displacement failed: {e}"
 

--- a/app/cli.py
+++ b/app/cli.py
@@ -136,6 +136,7 @@ def _run_single_preset(
                     )
         except Exception as e:
             import traceback
+
             traceback.print_exc()
             return preset_name, f"Displacement failed: {e}"
 
@@ -157,7 +158,6 @@ def _run_single_preset(
         filename: str = str(base_filename.with_suffix(f".{f}"))
         if verbose:
             print(f"[{preset_name}] Saving {f.upper()} to {filename}...")
-
         success: bool
         error_msg: str | None
         success, error_msg = _export(xPhys, nelxyz, filename, f)

--- a/app/cli.py
+++ b/app/cli.py
@@ -35,10 +35,12 @@ def _run_single_preset(
 
     xPhys: FloatArray | None = None
     u: FloatArray | None = None
-    cache_file: Path = (
-        Path("results") / preset_name / f"{preset_name}_density_field.npz"
-    )
-    if cache_file.exists():
+    # Detect if running from pytest and use tests/ instead of results/
+    is_pytest = os.environ.get("PYTEST_CURRENT_TEST") is not None
+    base_dir = "tests" if is_pytest else "results"
+    cache_file: Path = Path(base_dir) / preset_name / f"{preset_name}_density_field.npz"
+    cache_exists = cache_file.exists()
+    if cache_exists:
         if verbose:
             print(f"[{preset_name}] Loading cached density field...")
         try:
@@ -67,7 +69,7 @@ def _run_single_preset(
             def progress_callback(
                 iteration: int, objective: float, change: float, xPhys_frame: FloatArray
             ) -> bool:
-                folder: Path = Path("results") / preset_name / f"{preset_name}_creation"
+                folder: Path = Path(base_dir) / preset_name / f"{preset_name}_creation"
                 folder.mkdir(parents=True, exist_ok=True)
                 filename: Path = folder / f"{preset_name}_creation_{iteration}.png"
                 colors: list[str] | None = params.get("Materials", {}).get(
@@ -118,7 +120,7 @@ def _run_single_preset(
             ):
                 if save_frames:
                     folder: Path = (
-                        Path("results") / preset_name / f"{preset_name}_displacement"
+                        Path(base_dir) / preset_name / f"{preset_name}_displacement"
                     )
                     folder.mkdir(parents=True, exist_ok=True)
                     filename: Path = (

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -455,9 +455,13 @@ class MainWindow(QMainWindow, PlottingMixin, ParameterManagerMixin):
 
         preset_name = self.preset.presets_combo.currentText()
         if preset_name in self.presets:
-            os.makedirs(os.path.join("results", preset_name), exist_ok=True)
+            # Detect if running from pytest and use tests/ instead of results/
+            is_pytest = os.environ.get("PYTEST_CURRENT_TEST") is not None
+            base_dir = "tests" if is_pytest else "results"
+
+            os.makedirs(os.path.join(base_dir, preset_name), exist_ok=True)
             cache_file = os.path.join(
-                "results", preset_name, f"{preset_name}_density_field.npz"
+                base_dir, preset_name, f"{preset_name}_density_field.npz"
             )
             try:
                 np.savez_compressed(cache_file, xPhys=self.xPhys, u=self.u)


### PR DESCRIPTION
- Route test results to the /tests folder to prevent saved results from being overwritten using PYTEST_CURRENT_TEST.
- Fix paths in .gitignore.