### PR TITLE
Refactor application entry point

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
         run: ruff format --check .
 
       - name: Lizard (complexity & length)
-        run: lizard -L 150 -C 30 -w app main.py
+        run: lizard -L 150 -C 30 -w app tests
 
   tests:
     runs-on: ubuntu-latest
@@ -54,6 +54,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          pip install -e .
           pip install pytest pytest-cov
 
       - name: Run tests

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ __pycache__/
 # Build (when an executable is created)
 /dist/
 /build/
+*.egg-info/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
             "name": "Python: Run Main",
             "type": "python",
             "request": "launch",
-            "program": "${workspaceFolder}/main.py",
+            "module": "app",
             "console": "integratedTerminal",
             "cwd": "${workspaceFolder}",
             "justMyCode": true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Create an [issues](https://github.com/ninja7v/topoptcomec/issues).
 1. Create a branch for a single, focused change.
 2. Implement and add tests where appropriate.
 3. Install the dev dependencies: `python -m pip install -r requirements-dev.txt`
-4. Run formatting `ruff format .` and checks `ruff format --check . && ruff check . && lizard -L 150 -C 30 -w app main.py && pytest`.
+4. Run formatting `ruff format .` and checks `ruff format --check . && ruff check . && lizard -L 150 -C 30 -w app tests && pytest`.
 5. Open a pull request describing what you changed and why.
 
 Vibe coders are welcome, just make sure to read and understand every line!

--- a/README.md
+++ b/README.md
@@ -18,16 +18,16 @@ None of the existing competing solutions combine all of these features in a sing
 - 🔓 **Open source** — Transparent, extensible. No black boxes.
 
 ## 🚀Quick Start
-### Clone/Download the repo
+### 1. Clone the repo
 ```cmd
 git clone https://github.com/ninja7V/topoptcomec.git
 cd topoptcomec
 ```
-### Install dependencies
+### 2. Set up the environment (once)
+Create and activate a virtual environment:
 ```bash
 python -m venv .venv
 ```
-Then activate the virtual environment:
 - macOS / Linux:
 ```bash
 source .venv/bin/activate
@@ -40,19 +40,23 @@ source .venv/bin/activate
 ```cmd
 .\.venv\Scripts\activate.bat
 ```
-Install requirements:
+Then install:
 ```bash
 python -m pip install --upgrade pip
 python -m pip install -r requirements.txt
+python -m pip install -e .
 ```
-### Run
+
+### 3. Run
+> **Note:** Always activate the virtual environment first (see step 2) before running `topoptcomec`.
+
 GUI:
 ```bash
-python main.py
+topoptcomec
 ```
 CLI:
 ```bash
-python main.py -p ForceInverter_2Sup_2D --preview
+topoptcomec -p ForceInverter_2Sup_2D --preview
 ```
 ### Create
 Tweak the parameters or choose a preset and hit "Create"!

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -1,0 +1,51 @@
+# app/__main__.py
+# MIT License - Copyright (c) 2025-2026 Luc Prevost
+# Entry point for TopoptComec when invoked as a module or via console script.
+
+from __future__ import annotations
+import sys
+from pathlib import Path
+from PySide6.QtGui import QIcon
+from PySide6.QtWidgets import QApplication, QStyle
+from PySide6.QtSvg import (  # noqa: F401
+    QSvgRenderer,
+)  # make sure SVG support is available
+from app.ui.resource_path_finder import resource_path
+
+
+def main() -> None:
+    """Initializes and runs the Qt application."""
+    if len(sys.argv) > 1:
+        # CLI mode
+        from app.cli import run_cli
+
+        run_cli()
+    else:
+        # GUI mode
+        app: QApplication = QApplication(sys.argv)
+
+        icon_path: Path = resource_path("icons") / "window_icon.svg"
+        if icon_path.exists():
+            app_icon: QIcon = QIcon(str(icon_path))
+            if not app_icon.isNull():
+                app.setWindowIcon(app_icon)
+        else:
+            print(
+                f"Warning: Window icon not found at {icon_path}. Using a built-in icon."
+            )
+            fallback_icon: QIcon = app.style().standardIcon(
+                QStyle.StandardPixmap.SP_ComputerIcon
+            )
+            app.setWindowIcon(fallback_icon)
+
+        # Now that the app exists, import the main window
+        from app.ui.main_window import MainWindow
+
+        window: MainWindow = MainWindow()
+        window.show()
+
+        sys.exit(app.exec())
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -9,7 +9,8 @@ TopoptComec has two front doors built on the same core engine:
 
 ### Entry Points
 
-- `main.py`: chooses GUI when no arguments are passed, otherwise runs the CLI
+- `app/__main__.py`: chooses GUI when no arguments are passed, otherwise runs the CLI
+- `main.py`: convenience wrapper, delegates to `app/__main__:main`
 - `app/cli.py`: loads presets, runs optimization, exports results
 - `app/ui/main_window.py`: owns the main GUI workflow
 

--- a/docs/CODEMAP.md
+++ b/docs/CODEMAP.md
@@ -4,7 +4,8 @@ Quick map of the repository.
 
 ## Root
 
-- `main.py`: application entry point
+- `main.py`: convenience wrapper, delegates to `app/__main__:main`
+- `app/__main__.py`: application entry point (console script target)
 - `presets.json`: built-in preset definitions
 - `requirements.txt`: dependencies
 - `README.md`: user-facing overview
@@ -52,11 +53,11 @@ Quick map of the repository.
 
 ## Documentation
 
-- `doc/ARCHITECTURE.md`: high-level system design
-- `doc/CODEMAP.md`: this file
-- `doc/GLOSSARY.md`: terminology
-- `doc/EXAMPLE.md`: usage examples
-- `doc/SKILL.md`: agent-oriented repo guide
+- `docs/ARCHITECTURE.md`: high-level system design
+- `docs/CODEMAP.md`: this file
+- `docs/GLOSSARY.md`: terminology
+- `docs/EXAMPLE.md`: usage examples
+- `docs/SKILL.md`: agent-oriented repo guide
 
 ## Assets and Output
 

--- a/docs/EXAMPLE.md
+++ b/docs/EXAMPLE.md
@@ -3,7 +3,7 @@
 ## GUI
 
 ```bash
-py main.py
+topoptcomec
 ```
 
 Typical flow:
@@ -20,25 +20,25 @@ If you change parameters after a run, create the result again.
 Run one preset:
 
 ```bash
-py main.py -p ForceInverter_2Sup_2D
+topoptcomec -p ForceInverter_2Sup_2D
 ```
 
 Export only PNG:
 
 ```bash
-py main.py -p ForceInverter_2Sup_2D -f png
+topoptcomec -p ForceInverter_2Sup_2D -f png
 ```
 
 Threshold before export:
 
 ```bash
-py main.py -p ForceInverter_2Sup_2D -f png -t
+topoptcomec -p ForceInverter_2Sup_2D -f png -t
 ```
 
 Run several presets in parallel:
 
 ```bash
-py main.py -p ForceInverter_2Sup_2D,Gripper_2D -f png
+topoptcomec -p ForceInverter_2Sup_2D,Gripper_2D -f png
 ```
 
 ## Notes

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -1,6 +1,6 @@
 # TopoptComec Agent Skill
 
-TopoptComec is a Python topology optimization app with a GUI (`py main.py`) and a CLI (`py main.py -p <preset>`).
+TopoptComec is a Python topology optimization app with a GUI (`topoptcomec`) and a CLI (`topoptcomec -p <preset>`).
 
 ## Edit Map
 
@@ -35,6 +35,6 @@ Useful tests:
 ```bash
 ruff format --check .
 ruff check .
-lizard -L 150 -C 30 -w app main.py
+lizard -L 150 -C 30 -w app tests
 pytest
 ```

--- a/main.py
+++ b/main.py
@@ -1,51 +1,9 @@
 # main.py
 # MIT License - Copyright (c) 2025-2026 Luc Prevost
-# Entry point of TopoptComec.
+# Convenience wrapper for running TopoptComec.
+# For the actual entry point, see app/__main__.py
 
-from __future__ import annotations
-import sys
-from pathlib import Path
-from PySide6.QtGui import QIcon
-from PySide6.QtWidgets import QApplication, QStyle
-from PySide6.QtSvg import (  # noqa: F401
-    QSvgRenderer,
-)  # make sure SVG support is available
-from app.ui.resource_path_finder import resource_path
-
-
-def main() -> None:
-    """Initializes and runs the Qt application."""
-    if len(sys.argv) > 1:
-        # CLI mode
-        from app.cli import run_cli
-
-        run_cli()
-    else:
-        # GUI mode
-        app: QApplication = QApplication(sys.argv)
-
-        icon_path: Path = resource_path("icons") / "window_icon.svg"
-        if icon_path.exists():
-            app_icon: QIcon = QIcon(str(icon_path))
-            if not app_icon.isNull():
-                app.setWindowIcon(app_icon)
-        else:
-            print(
-                f"Warning: Window icon not found at {icon_path}. Using a built-in icon."
-            )
-            fallback_icon: QIcon = app.style().standardIcon(
-                QStyle.StandardPixmap.SP_ComputerIcon
-            )
-            app.setWindowIcon(fallback_icon)
-
-        # Now that the app exists, import the main window
-        from app.ui.main_window import MainWindow
-
-        window: MainWindow = MainWindow()
-        window.show()
-
-        sys.exit(app.exec())
-
+from app.__main__ import main
 
 if __name__ == "__main__":
     main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,51 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "topoptcomec"
+version = "0.1.0"
+description = "Interactive topology optimization for compliant mechanisms"
+readme = "README.md"
+license = {text = "MIT"}
+authors = [{name = "Luc Prevost"}]
+keywords = ["topology-optimization", "compliant-mechanisms", "engineering"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+]
+requires-python = ">=3.10"
+dependencies = [
+    "pyside6",
+    "numpy",
+    "scipy",
+    "matplotlib",
+    "vtk",
+    "PyMCubes",
+    "numpy-stl",
+    "lib3mf",
+]
+
+[project.urls]
+Homepage = "https://github.com/ninja7V/topoptcomec"
+Repository = "https://github.com/ninja7V/topoptcomec.git"
+Documentation = "https://github.com/ninja7v/TopoptComec/wiki"
+Issues = "https://github.com/ninja7V/topoptcomec/issues"
+
+[project.scripts]
+topoptcomec = "app.__main__:main"
+
+[tool.setuptools]
+packages = ["app", "app.core", "app.ui"]
+include-package-data = true
+
+[tool.setuptools.package-data]
+app = ["icons/*"]


### PR DESCRIPTION
- Moved the main application logic to app/__main__.py and use main.py to serve as a convenience wrapper.
- Add a pyproject.toml to be able to start the program with "topoptcomec" instead of "python main.py"
- Take care or documentation

Advantages & Impacts:
Provides a standard, package-installable entry point and isolates dependencies within the virtual environment without affecting start times or performance.